### PR TITLE
Allow template placeholders to be any type in typings

### DIFF
--- a/oneline.d.ts
+++ b/oneline.d.ts
@@ -1,3 +1,3 @@
-declare function OneLine(literals: TemplateStringsArray, ...placeholders: string[]): string
+declare function OneLine(literals: TemplateStringsArray, ...placeholders: any[]): string
 
 export = OneLine


### PR DESCRIPTION
I was attempting to use this library but ran into an issue with non-string placeholders that I hadn't seen using similar libraries like `dedent`.

```js
const foo = 5;
echo oneline`
  This is a long string with a number interpolation
  (${foo}) in the middle of it.
`;
// error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.
```